### PR TITLE
Add data class for potential issue test

### DIFF
--- a/Data.cpp
+++ b/Data.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <vector>
+
+class DataContainer {
+public:
+    DataContainer(int size) {
+        data = new int[size]; // Potential flaw: no delete[]
+    }
+
+    int& operator[](int index) {
+        return data[index];
+    }
+
+private:
+    int* data;
+};
+
+class DataProcessor {
+public:
+    void processData(DataContainer& container) {
+        for (int i = 0; i < 10; ++i) {
+            container[i] = i * 2;
+        }
+    }
+};
+
+int main() {
+    DataContainer container(5);
+    DataProcessor processor;
+    processor.processData(container);
+
+    // ... other code that might use container
+
+    return 0;
+}
+
+
+
+//Just test:wq


### PR DESCRIPTION
Explanation of the flaw:Memory leak

DataContainer class:
 The constructor allocates memory for an interger array using new
 There's no corresponding delete[] for free the memory when the object
 goes out of scope leading to memeory leak

DataProcessor class:
  Uses the DataContainer to process data.
  Unknowningly contributes to the memory leak by using the container